### PR TITLE
feat: use golang.org/x/mod to parse `go.mod` file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/tebeka/expmod
 
 go 1.21
 
-require github.com/stretchr/testify v1.8.4
+require (
+	github.com/stretchr/testify v1.8.4
+	golang.org/x/mod v0.14.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 }
 
 func pkgsInfo(r io.Reader, cache map[string]string) error {
-	data, err := io.ReadAll(r)
+	data, err := io.ReadAll(io.LimitReader(r, 1<<24)) // go.mod files are limited to 16 MiB
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func pkgsInfo(r io.Reader, cache map[string]string) error {
 			cache[key] = desc
 		}
 
-		fmt.Printf("%s:\n\t%s\n", line, desc)
+		fmt.Printf("%s %s:\n\t%s\n", line, require.Mod.Version, desc)
 	}
 
 	if err := s.Err(); err != nil {


### PR DESCRIPTION
Use `golang.org/x/mod` to do a formal parsing of `go.mod` file.